### PR TITLE
Update new post form title

### DIFF
--- a/app/views/listings/form/_origin.haml
+++ b/app/views/listings/form/_origin.haml
@@ -1,5 +1,5 @@
 - required = Maybe(@current_community).listing_location_required.or_else { false }
-- title = t(".location_for_pup") + (required ? "*" : "")
+- title = t("listings.form.location.location_for_pup") + (required ? "*" : "")
 - required_class = (required ? "required" : "")
 
 = form.label :origin, title, :class => "input"

--- a/client/app/components/elements/AddNewListingButton/AddNewListingButton.js
+++ b/client/app/components/elements/AddNewListingButton/AddNewListingButton.js
@@ -12,7 +12,7 @@ import css from './AddNewListingButton.css';
 const HOVER_COLOR_BRIGHTNESS = 80;
 
 export default function AddNewListingButton({ text, url, customColor, className, mobileLayoutOnly }) {
-  const buttonText = `+ ${text}`;
+  const buttonText = `${text}`;
   const color = customColor || variables['--AddNewListingButton_defaultColor'];
 
   // We have added hoverColor calucalation because IE11 doesn't support CSS filters yet

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1143,7 +1143,7 @@ en:
       default_about_text: "This marketplace is powered by Sharetribe platform. With Sharetribe you can easily create your own marketplace website. It's free and only takes a minute. %{click_here_link} to learn more!"
       click_here_link_text: "Click here"
     how_to_use:
-      default_title: "How it works"
+      default_title: "How to / FAQ"
       default_content: "Here you can find information about how %{marketplace_name} works."
   landing_page:
     hero:
@@ -1192,7 +1192,7 @@ en:
       select_language: "Select language"
     infos:
       about: About
-      how_to_use: "How it works"
+      how_to_use: "How to / FAQ"
       info_about_kassi: "Information about %{service_name}"
       news: News
       register_details: Privacy


### PR DESCRIPTION
#5

Could you change the navigation link text on the how it works page from "How it works" to "How to / FAQ".

Attached: "howitworks_current" to "howitworks_new"

Could you also change this navigation text on the mobile version so that the menu text of "How it works" is changed to "How to / FAQ".


#6

Please delete the "+" from the button in the top left corner... so this...
"+ Add your pup"
is changed to...
"Add your pup"